### PR TITLE
change Deepl client's URL depending on the api key

### DIFF
--- a/crates/api/deepl/src/lib.rs
+++ b/crates/api/deepl/src/lib.rs
@@ -106,8 +106,8 @@ impl AsyncTranslator for DeeplTranslator {
 pub async fn get_languages(auth: &String) -> anyhow::Result<Vec<String>> {
     let client = Client::new();
 
-    let mut url = Url::parse(get_url(auth))?;
-    url.path_segments_mut().unwrap().push("v2").push("languages");
+    let mut url = Url::parse(get_url(auth))?
+        .join("v2/languages");
     url.set_query(Some("type=source"));
 
     let response = client

--- a/crates/api/deepl/src/lib.rs
+++ b/crates/api/deepl/src/lib.rs
@@ -78,8 +78,7 @@ impl AsyncTranslator for DeeplTranslator {
             None => json!({"text": query,
                 "target_lang": to.to_deepl()}),
         };
-        let mut url = Url::parse(self.url)?;
-        url.path_segments_mut().unwrap().push("v2").push("translate");
+        let url = Url::parse(&self.url)?.join("v2/translate")?;
 
         let request: Root1 = self
             .client

--- a/crates/api/deepl/src/lib.rs
+++ b/crates/api/deepl/src/lib.rs
@@ -40,7 +40,7 @@ impl DeeplTranslator {
     }
 }
 fn get_url(auth: &String) -> &'static str {
-    if auth.clone().ends_with(":fx") { "https://api-free.deepl.com" } else { "https://api.deepl.com/" }
+    if auth.ends_with(":fx") { "https://api-free.deepl.com/" } else { "https://api.deepl.com/" }
 }
 #[async_trait::async_trait]
 impl AsyncTranslator for DeeplTranslator {


### PR DESCRIPTION
The current implementation only works with free accounts. This version will choose between `https://api-free.deepl.com` and `https://api-free.deepl.com` depending on whether the api key ends with ":fx", i.e. free, or not.

mirrors the official client's behavior https://github.com/DeepLcom/deepl-java/blob/e91115a0cee340d8770210352bc08144dce1fbe8/deepl-java/src/main/java/com/deepl/api/Translator.java#L117-L119

I don't really know how to write rust so let me know if theres wrong with what I've done.